### PR TITLE
fix: pass through cookie lifetime from widar constructor

### DIFF
--- a/classes/Widar.php
+++ b/classes/Widar.php
@@ -21,10 +21,10 @@ class Widar {
 	public $authorization_callback = '' ;
 	public $authorize_parameters = '' ; # Optional parameters to 'authorize' call
 
-	public function __construct ( /*string*/ $toolname = '' ) {
+	public function __construct ( /*string*/ $toolname = '', $cookie_lifetime = null ) {
 		$this->tfc = new Common ( $toolname ) ;
 		try {
-			$this->oa = new OAuth ( $this->toolname() , 'wikidata' , 'wikidata' ) ;
+			$this->oa = new OAuth ( $this->toolname() , 'wikidata' , 'wikidata', $cookie_lifetime ) ;
 		} catch ( Exception $e ) { # Error
 			// Ignore error
 		}


### PR DESCRIPTION
I missed this in #8, where I expected the code for Widar to live in `wbstack/widar` when the source code for the class itself really is part of this repository.