### PR TITLE
fix: also apply cookie lifetime changes to classes in public_html

### DIFF
--- a/public_html/php/Widar.php
+++ b/public_html/php/Widar.php
@@ -24,7 +24,7 @@ class Widar {
 	public $authorization_callback = '' ;
 	public $authorize_parameters = '' ; # Optional parameters to 'authorize' call
 
-	public function __construct ( /*string*/ $toolname = '' ) {
+	public function __construct ( /*string*/ $toolname = '', $cookie_lifetime = null ) {
 		$this->tfc = new ToolforgeCommon ( $toolname ) ;
 		try {
 			// $this->oa = new MW_OAuth ( $this->toolname() , 'wikidata' , 'wikidata' ) ;
@@ -44,7 +44,8 @@ class Widar {
 			);
 			$this->oa = new MW_OAuth ( WbstackMagnusOauth::getOauthParams(
 				'widar',
-				'/tools/widar'
+				'/tools/widar',
+				$cookie_lifetime
 			) ) ;
 			// WBStack customization END
 


### PR DESCRIPTION
This applies the changes from #8 and #9 to the classes in `public_html` as this seems to be where `wbstack/widar` is loading them from.