### PR TITLE
Correctly configure entityBase https for prod sites

### DIFF
--- a/public_html/php/WbstackMagnusOauth.php
+++ b/public_html/php/WbstackMagnusOauth.php
@@ -185,6 +185,7 @@ class WbstackMagnusOauth {
             $wbApi = 'http://' . self::platformIngressHostAndPort . '/w/api.php';
             $wbPageBase = $wbRoot . '/wiki/';
             $toolbase = $toolRoot;
+            $entityBase = 'http://' . $wbRoot . '/entity/';
         } else {
             $wbRoot = $domain;
             $toolRoot = $domain . $toolUrlTail;
@@ -196,8 +197,8 @@ class WbstackMagnusOauth {
             $wbApi = 'https://' . $wbRoot . '/w/api.php'; // TODO this could use the internal network
             $wbPageBase = 'https://' . $wbRoot . '/wiki/';
             $toolbase = 'https://' . $toolRoot;
+            $entityBase = 'https://' . $wbRoot . '/entity/';
         }
-        $entityBase = 'http://' . $wbRoot . '/entity/';
 
         $site = [
             'oauth' => [


### PR DESCRIPTION
This is assuming that all wikis that make use of these
wbstack projects have concept URIs set to https.

Based on the current mediawiki repo, that is true...
https://github.com/wbstack/mediawiki/blob/main/dist-persist/wbstack/src/Settings/LocalSettings.php#L527

Bug: T325871
