### PR TITLE
fix: cookie_lifetime param is misplaced

### DIFF
--- a/public_html/php/Widar.php
+++ b/public_html/php/Widar.php
@@ -45,8 +45,7 @@ class Widar {
 			$this->oa = new MW_OAuth ( WbstackMagnusOauth::getOauthParams(
 				'widar',
 				'/tools/widar',
-				$cookie_lifetime
-			) ) ;
+			), $cookie_lifetime ) ;
 			// WBStack customization END
 
 


### PR DESCRIPTION
#11 passed the `$cookie_lifetime` parameter in the wrong place. It is a parameter of `MW_OAuth` not `getOauthParams`