### PR TITLE
Reduce the use of localhost workarounds

### DIFF
--- a/classes/Common.php
+++ b/classes/Common.php
@@ -375,9 +375,6 @@ final class Common {
 				curl_setopt($ch[$key], CURLOPT_RETURNTRANSFER, true);
 				curl_setopt($ch[$key], CURLOPT_SSL_VERIFYPEER, false);
 				curl_setopt($ch[$key], CURLOPT_SSL_VERIFYHOST, false);
-
-				WbstackMagnusOauth::setCurlHttpHeaders( $ch[$key] );
-
 				curl_multi_add_handle($mh,$ch[$key]);
 			}
 	

--- a/public_html/php/WbstackMagnusOauth.php
+++ b/public_html/php/WbstackMagnusOauth.php
@@ -158,10 +158,6 @@ class WbstackMagnusOauth {
         return $params;
     }
 
-    public static function isLocalHost(): bool {
-        return substr($_SERVER['SERVER_NAME'], -10, 10) === '.localhost';
-    }
-
     /**
      * @param string $toolUrlTail Example: "/tools/widar"
      * @return mixed
@@ -171,34 +167,15 @@ class WbstackMagnusOauth {
     ) {
         // XXX: this same logic is in quickstatements.php and platform api WikiController backend
         $domain = $_SERVER['SERVER_NAME'];
-        if ( self::isLocalHost() ){
-
-            // localhost development, with a full domain prefixing .localhost
-            // eg. wiki.addshore.com.localhost
-            $wbRoot = $domain;
-            $toolRoot = 'http://' . $domain . $toolUrlTail;
-
-            // Directly for config
-            $publicMwOAuthUrl = 'http://' . $domain . '/w/index.php?title=Special:OAuth';
-            $mwOAuthUrl = 'http://' . self::platformIngressHostAndPort . '/w/index.php?title=Special:OAuth';
-            $wbPublicHostAndPort = $wbRoot;
-            $wbApi = 'http://' . self::platformIngressHostAndPort . '/w/api.php';
-            $wbPageBase = $wbRoot . '/wiki/';
-            $toolbase = $toolRoot;
-            $entityBase = 'http://' . $wbRoot . '/entity/';
-        } else {
-            $wbRoot = $domain;
-            $toolRoot = $domain . $toolUrlTail;
-
-            // Directly for config
-            $publicMwOAuthUrl = 'https://' . $wbRoot . '/w/index.php?title=Special:OAuth'; // TODO this could use the internal network
-            $mwOAuthUrl = 'https://' . $wbRoot . '/w/index.php?title=Special:OAuth';
-            $wbPublicHostAndPort = $wbRoot;
-            $wbApi = 'https://' . $wbRoot . '/w/api.php'; // TODO this could use the internal network
-            $wbPageBase = 'https://' . $wbRoot . '/wiki/';
-            $toolbase = 'https://' . $toolRoot;
-            $entityBase = 'https://' . $wbRoot . '/entity/';
-        }
+        $wbRoot = $domain;
+        $toolRoot = $domain . $toolUrlTail;
+        $publicMwOAuthUrl = 'https://' . $wbRoot . '/w/index.php?title=Special:OAuth'; // TODO this could use the internal network
+        $mwOAuthUrl = 'https://' . $wbRoot . '/w/index.php?title=Special:OAuth';
+        $wbPublicHostAndPort = $wbRoot;
+        $wbApi = 'https://' . $wbRoot . '/w/api.php'; // TODO this could use the internal network
+        $wbPageBase = 'https://' . $wbRoot . '/wiki/';
+        $toolbase = 'https://' . $toolRoot;
+        $entityBase = 'https://' . $wbRoot . '/entity/';
 
         $site = [
             'oauth' => [
@@ -223,22 +200,4 @@ class WbstackMagnusOauth {
         $site = json_decode(json_encode($site));
         return $site;
     }
-
-	/**
-	 * Set the HTTP Headers for the curl handle
-	 *
-	 * Sets the HOST parameter when internally talking to wbstack platform ingress
-	 *
-	 */
-	public static function setCurlHttpHeaders( $curlHandle, $headers = [] ) {
-
-		if( WbstackMagnusOauth::isLocalHost() ) {
-			$domain = $_SERVER['SERVER_NAME'];
-			$headers[] = 'HOST: ' . $domain;
-		}
-	
-		if( !empty($headers) ) {
-			curl_setopt( $curlHandle, CURLOPT_HTTPHEADER, $headers );
-		}
-	}
 }

--- a/public_html/php/oauth.php
+++ b/public_html/php/oauth.php
@@ -155,10 +155,7 @@ class MW_OAuth {
 		curl_setopt( $ch, CURLOPT_URL, $url );
 		//curl_setopt( $ch, CURLOPT_SSL_VERIFYPEER, false );
 		curl_setopt( $ch, CURLOPT_USERAGENT, $this->gUserAgent );
-
 		curl_setopt( $ch, CURLOPT_HEADER, 0 );
-		WbstackMagnusOauth::setCurlHttpHeaders( $ch );
-
 		curl_setopt( $ch, CURLOPT_RETURNTRANSFER, 1 );
 		$data = curl_exec( $ch );
 
@@ -285,7 +282,6 @@ class MW_OAuth {
 		//curl_setopt( $ch, CURLOPT_SSL_VERIFYPEER, false );
 		curl_setopt( $ch, CURLOPT_USERAGENT, $this->gUserAgent );
 		curl_setopt( $ch, CURLOPT_HEADER, 0 );
-		WbstackMagnusOauth::setCurlHttpHeaders( $ch );
 		curl_setopt( $ch, CURLOPT_RETURNTRANSFER, 1 );
 		$data = curl_exec( $ch );
 		if ( !$data ) {
@@ -503,12 +499,10 @@ class MW_OAuth {
 		curl_setopt( $ch, CURLOPT_POST, true );
 		curl_setopt( $ch, CURLOPT_URL, $url );
 		curl_setopt( $ch, CURLOPT_POSTFIELDS, $post_fields );
+		curl_setopt( $ch, CURLOPT_HTTPHEADER, [ $header ] );
 		//curl_setopt( $ch, CURLOPT_SSL_VERIFYPEER, false );
 		curl_setopt( $ch, CURLOPT_USERAGENT, $this->gUserAgent );
-
 		curl_setopt( $ch, CURLOPT_HEADER, 0 );
-		WbstackMagnusOauth::setCurlHttpHeaders( $ch, [ $header ] );
-
 		curl_setopt( $ch, CURLOPT_RETURNTRANSFER, 1 );
 
 		$data = curl_exec( $ch );

--- a/public_html/php/wikidata.php
+++ b/public_html/php/wikidata.php
@@ -180,9 +180,6 @@ class WikidataItemList {
 				curl_setopt($ch[$key], CURLOPT_RETURNTRANSFER, true);
 				curl_setopt($ch[$key], CURLOPT_SSL_VERIFYPEER, false);
 				curl_setopt($ch[$key], CURLOPT_SSL_VERIFYHOST, false);
-
-				WbstackMagnusOauth::setCurlHttpHeaders( $ch[$key] );
-
 				curl_multi_add_handle($mh,$ch[$key]);
 			}
 	


### PR DESCRIPTION
This patch requires adding the following to the Corefile of CoreDNS:

```
wbaas.localhost:53 {
  log
  errors
  template IN ANY {
    match "^(.*)wbaas\.localhost\.$"
    answer "{{.Name}} 60 IN CNAME ingress-nginx-controller.kube-system.svc.cluster.local"
  }
}
```

This can be done using:
```
kubectl --context minikube-wbaas edit --namespace kube-system configmap/coredns
```